### PR TITLE
Implement Error Management System

### DIFF
--- a/src/cweb-stress/client/thread.c
+++ b/src/cweb-stress/client/thread.c
@@ -35,13 +35,14 @@ void* client__thread_main(void* tmp) {
     req.body = body;
 
     // Create raw HTTP request.
-    buffer = utils__http_request_write(&req);
+    if (utils__http_request_write(&req, &buffer)) {
+        error_ctx_t* err = utils__error_ctx();
 
-    if (!buffer) {
-        fprintf(stderr, "[T %d] Failed to construct and write HTTP request.\n", tctx->id);
+        fprintf(stderr, "[T %d] Failed to create raw HTTP request: %s (%d)", tctx->id, err->msg, err->code);
 
         goto thread_exit;
     }
+
 
     // Resolve host.
     struct sockaddr_in sin = {0};
@@ -82,7 +83,7 @@ void* client__thread_main(void* tmp) {
         }
 
         if (connect(sock_fd, (struct sockaddr *)&sin, sizeof(sin)) != 0) {
-            fprintf(stderr, "[T %d] Failed to connect to host using connect(): %s\n", tctx->id, strerror(errno));
+            fprintf(stderr, "[T %d] Failed to connect to host using connect(): %s (%d)\n", tctx->id, strerror(errno), errno);
 
             close(sock_fd);
 

--- a/src/cweb-stress/client/thread.h
+++ b/src/cweb-stress/client/thread.h
@@ -9,6 +9,7 @@
 
 #include <utils/http/common.h>
 #include <utils/http/request.h>
+#include <utils/error/error.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/cweb/config/config.c
+++ b/src/cweb/config/config.c
@@ -31,19 +31,17 @@ void cfg__defaults(config_t* cfg) {
  * @return 0 on success or error from utils__read_file() or cfg__parse().
  */
 int cfg__load(config_t* cfg, const char* cfg_path, int load_defaults) {
-    int ret;
-
     // Check for defaults.
     if (load_defaults)
         cfg__defaults(cfg);
 
     char *buffer = NULL;
 
-    if ((ret = utils__read_file(cfg_path, &buffer)) != 0)
-        return ret;
+    if (utils__read_file(cfg_path, &buffer))
+        return 1;
 
-    if ((ret = cfg__parse(cfg, buffer)) != 0)
-        return ret;
+    if (cfg__parse(cfg, buffer))
+        return 1;
 
     free(buffer);
 
@@ -56,7 +54,7 @@ int cfg__load(config_t* cfg, const char* cfg_path, int load_defaults) {
  * @param cfg A pointer to the config.
  * @param data The JSON data to parse.
  * 
- * @return 0 on success or 1 if json_tokener_parse() fails.
+ * @return 0 on success or 1 on error.
  */
 int cfg__parse(config_t* cfg, const char* data) {
     json_object *root, *obj;
@@ -64,8 +62,11 @@ int cfg__parse(config_t* cfg, const char* data) {
     // Load root JSON contents.
     root = json_tokener_parse(data);
 
-    if (!root)
+    if (!root) {
+        ERR_SET(1, "Failed to parse JSON.");
+        
         return 1;
+    }
 
     // Retrieve log level.
     json_object *log_lvl = json_object_object_get(root, "log_lvl");

--- a/src/cweb/fs/web.h
+++ b/src/cweb/fs/web.h
@@ -6,6 +6,8 @@
 #include <utils/constants.h>
 #include <utils/int_types.h>
 
+#include <utils/error/error.h>
+
 #include <utils/file/read.h>
 
-char* fs__web_get_html(char* uri, const char* fs_root);
+int fs__web_get_html(char* uri, const char* fs_root, char** buffer);

--- a/src/cweb/logger/logger.h
+++ b/src/cweb/logger/logger.h
@@ -3,6 +3,8 @@
 #include <utils/constants.h>
 #include <utils/int_types.h>
 
+#include <utils/error/error.h>
+
 #include <cweb/config/config.h>
 
 #include <stdio.h>
@@ -10,6 +12,8 @@
 #include <stdarg.h>
 
 #include <time.h>
+
+#include <errno.h>
 
 enum log_level {
     LVL_FATAL = 1,

--- a/src/cweb/prog.c
+++ b/src/cweb/prog.c
@@ -4,6 +4,8 @@
 #include <utils/constants.h>
 #include <utils/int_types.h>
 
+#include <utils/error/error.h>
+
 #include <utils/string/copy.h>
 
 #include <cweb/cli/cli.h>
@@ -52,7 +54,9 @@ int main(int argc, char** argv) {
     config_t cfg = {0};
 
     if ((ret = cfg__load(&cfg, cli.cfg_path, 1)) != 0) {
-        logger__log(&cfg, LVL_FATAL, "Failed to load config '%s' (code => %d).", cli.cfg_path, ret);
+        error_ctx_t *err = utils__error_ctx();
+
+        logger__log(&cfg, LVL_FATAL, "Failed to load config '%s': %s (%d).", cli.cfg_path, err->msg, err->code);
 
         return EXIT_FAILURE;
     }
@@ -82,7 +86,9 @@ int main(int argc, char** argv) {
 
     // Spin up web server.
     if ((ret = server__setup(&ctx, threads)) != 0) {
-        logger__log(&cfg, LVL_FATAL, "Failed to setup web server: %d", ret);
+        error_ctx_t *err = utils__error_ctx();
+
+        logger__log(&cfg, LVL_FATAL, "Failed to setup web server: %s (%d)", err->msg, err->code);
 
         return EXIT_FAILURE;
     }
@@ -117,7 +123,7 @@ int main(int argc, char** argv) {
 
     // Attempt to shut down web server.
     if ((ret = server__shutdown(threads)) != 0) {
-        logger__log(&cfg, LVL_ERROR, "Failed to shutdown all web server threads (%d).", ret);
+        logger__log(&cfg, LVL_ERROR, "Failed to shutdown all web server threads: %d.", ret);
 
         return EXIT_FAILURE;
     }

--- a/src/cweb/server/server.h
+++ b/src/cweb/server/server.h
@@ -3,8 +3,11 @@
 #include <utils/constants.h>
 #include <utils/int_types.h>
 
+#include <utils/error/error.h>
+
 #include <cweb/server/thread.h>
 #include <cweb/server/socket.h>
+#include <cweb/logger/logger.h>
 
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/src/cweb/server/socket.h
+++ b/src/cweb/server/socket.h
@@ -3,6 +3,8 @@
 #include <utils/constants.h>
 #include <utils/int_types.h>
 
+#include <utils/error/error.h>
+
 #include <cweb/fs/web.h>
 #include <cweb/server/thread.h>
 
@@ -10,5 +12,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+
+#include <errno.h>
 
 int server__socket_setup(int* sock_fd, const char* bind_addr, u16 bind_port, int allow_reuse_port);

--- a/src/cweb/server/thread.h
+++ b/src/cweb/server/thread.h
@@ -3,6 +3,8 @@
 #include <utils/constants.h>
 #include <utils/int_types.h>
 
+#include <utils/error/error.h>
+
 #include <utils/http/common.h>
 #include <utils/http/request.h>
 #include <utils/http/response.h>
@@ -11,6 +13,7 @@
 
 #include <cweb/fs/web.h>
 #include <cweb/server/socket.h>
+#include <cweb/logger/logger.h>
 
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/src/utils/error/error.c
+++ b/src/utils/error/error.c
@@ -2,6 +2,15 @@
 
 error_ctx_t err_ctx = {0};
 
+/**
+ * Sets a custom error.
+ * 
+ * @param code The error code.
+ * @param func The name of the function the error occured in.
+ * @param msg The error message with argument support.
+ * 
+ * @return void
+ */
 void utils__error_set(int code, const char* func, const char* msg, ...) {
     err_ctx.code = code;
 
@@ -16,6 +25,11 @@ void utils__error_set(int code, const char* func, const char* msg, ...) {
     va_end(args);
 }
 
+/**
+ * Retrieves the current error context.
+ * 
+ * @return A pointer to the current error context declared in the global scope.
+ */
 error_ctx_t* utils__error_ctx() {
     return &err_ctx;
 }

--- a/src/utils/error/error.c
+++ b/src/utils/error/error.c
@@ -1,0 +1,21 @@
+#include "error.h"
+
+error_ctx_t err_ctx = {0};
+
+void utils__error_set(int code, const char* func, const char* msg, ...) {
+    err_ctx.code = code;
+
+    utils__str_copy(err_ctx.func, func, sizeof(err_ctx.func));
+
+    // Format message and assign to context message.
+    va_list args;
+    va_start(args, msg);
+
+    vsnprintf(err_ctx.msg, sizeof(err_ctx.msg), msg, args);
+    
+    va_end(args);
+}
+
+error_ctx_t* utils__error_ctx() {
+    return &err_ctx;
+}

--- a/src/utils/error/error.h
+++ b/src/utils/error/error.h
@@ -11,8 +11,13 @@
 
 #define ERR_MSG_MAX_LEN 1024
 
+#define ERR_SET(code, msg, ...) utils__error_set((code), __func__, (msg), ##__VA_ARGS__)
+
 struct error_ctx {
     int code;
     char msg[ERR_MSG_MAX_LEN];
     char func[MAX_NAME_LEN];
 } typedef error_ctx_t;
+
+void utils__error_set(int code, const char* func, const char* msg, ...);
+error_ctx_t* utils__error_ctx();

--- a/src/utils/error/error.h
+++ b/src/utils/error/error.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <utils/constants.h>
+#include <utils/int_types.h>
+
+#include <utils/string/copy.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define ERR_MSG_MAX_LEN 1024
+
+struct error_ctx {
+    int code;
+    char msg[ERR_MSG_MAX_LEN];
+    char func[MAX_NAME_LEN];
+} typedef error_ctx_t;

--- a/src/utils/error/error.h
+++ b/src/utils/error/error.h
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <unistd.h>
 
 #define ERR_MSG_MAX_LEN 1024

--- a/src/utils/file/read.c
+++ b/src/utils/file/read.c
@@ -6,13 +6,16 @@
  * @param path The path/file to read.
  * @param buffer A pointer to pointer of the buffer.
  * 
- * @return 0 on success. 1 on fopen() error. 2 on invalid file size. 3 on buffer allocation error.
+ * @return 0 on success or 1 on error.
  */
 int utils__read_file(const char* path, char** buffer) {
     FILE *fp = fopen(path, "r");
 
-    if (!fp)
+    if (!fp) {
+        ERR_SET(2, "Failed to open file: %s (%d).", strerror(errno), errno);
+
         return 1;
+    }
 
     fseek(fp, 0, SEEK_END);
     ssize_t file_sz = ftell(fp);
@@ -21,7 +24,9 @@ int utils__read_file(const char* path, char** buffer) {
     if (file_sz <= 0) {
         fclose(fp);
 
-        return 2;
+        ERR_SET(2, "File size is invalid.");
+
+        return 1;
     }
 
     *buffer = malloc(file_sz + 1);
@@ -29,7 +34,9 @@ int utils__read_file(const char* path, char** buffer) {
     if (*buffer == NULL) {
         fclose(fp);
 
-        return 3;
+        ERR_SET(3, "Failed to allocate buffer.");
+
+        return 1;
     }
 
     size_t r = fread(*buffer, 1, file_sz, fp);
@@ -53,6 +60,8 @@ int utils__file_exists(const char* path) {
 
     if (fp) {
         fclose(fp);
+
+        ERR_SET(1, "Failed to open file '%s': %s (%d)", path, strerror(errno), errno);
 
         return 1;
     }

--- a/src/utils/file/read.h
+++ b/src/utils/file/read.h
@@ -3,10 +3,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-
 #include <string.h>
-
 #include <ctype.h>
+
+#include <errno.h>
+
+#include <utils/error/error.h>
 
 int utils__read_file(const char* path, char** buffer);
 int utils__file_exists(const char* path);

--- a/src/utils/http/common.h
+++ b/src/utils/http/common.h
@@ -7,7 +7,7 @@
 #include <utils/string/trim.h>
 #include <utils/string/copy.h>
 
-#include <cweb/logger/logger.h>
+#include <utils/error/error.h>
 
 #include <string.h>
 

--- a/src/utils/http/request.c
+++ b/src/utils/http/request.c
@@ -6,19 +6,25 @@
  * @param req A pointer to the HTTP request.
  * @param line The line to parse.
  * 
- * @return 0 on success. 1 on line copy fail. 2 on error due to incorrect space count. 3 on error with splitting by spaces. 4 on error parsing.
+ * @return 0 on success or 1 on error.
  */
 int utils__http_request_parse_info(http_request_t* req, char* line) {
     char *line_cpy = strdup(line);
 
-    if (!line_cpy)
+    if (!line_cpy) {
+        ERR_SET(1, "Failed to copy line.");
+
         return 1;
+    }
 
     // Make sure we have enough spaces.
     int space_cnt = utils__get_delim_cnt(line_cpy, ' ');
 
-    if (space_cnt < 2)
-        return 2;
+    if (space_cnt < 2) {
+        ERR_SET(2, "Space count under 2.");
+
+        return 1;
+    }
 
     // Split string by spaces.
     char **tokens = utils__str_split(line_cpy, ' ');
@@ -26,14 +32,47 @@ int utils__http_request_parse_info(http_request_t* req, char* line) {
     if (!tokens) {
         free(line_cpy);
 
-        return 3;
+        ERR_SET(3, "Failed to split string.");
+
+        return 1;
     }
 
-    // Make sure we have at least 3 strings to use.
-    if (*(tokens) == NULL || *(tokens + 1) == NULL || *(tokens + 2) == NULL) {
+    // Check method.
+    if (*(tokens) == NULL) {
         free(line_cpy);
 
-        return 4;
+        free(tokens);
+
+        ERR_SET(4, "No method or malformed request.");
+
+        return 1;
+    }
+
+    // Check path.
+    if (*(tokens + 1) == NULL) {
+        free(line_cpy);
+
+        free(*(tokens));
+
+        free(tokens);
+
+        ERR_SET(5, "No path or malformed request.");
+
+        return 1;
+    }
+
+    // Check HTTP version.
+    if (*(tokens + 2) == NULL) {
+        free(line_cpy);
+
+        free(*(tokens));
+        free(*(tokens + 1));
+
+        free(tokens);
+
+        ERR_SET(6, "No HTTP version or malformed request.");
+
+        return 1;
     }
 
     // Assign method, path, and version from tokens.
@@ -58,7 +97,7 @@ int utils__http_request_parse_info(http_request_t* req, char* line) {
  * @param req A pointer to the request.
  * @param line The line to parse.
  * 
- * @return 0 on success or code from utils__http_header_parse_raw().
+ * @return 0 on success or 1 on error.
  */
 int utils__http_request_header_parse(http_request_t* req, char* line) {
     return utils__http_header_parse_raw(req->headers, &req->headers_cnt, line);
@@ -70,7 +109,7 @@ int utils__http_request_header_parse(http_request_t* req, char* line) {
  * @param req A pointer to the HTTP request.
  * @param buffer The full HTTP request.
  * 
- * @return 0 on success. 2 or 3 on malformed HTTP request. 4 on malformed HTTP header.
+ * @return 0 on success or 1 on error.
  */
 int utils__http_request_parse(http_request_t* req, char* buffer) {
     int ret = 0;
@@ -81,6 +120,8 @@ int utils__http_request_parse(http_request_t* req, char* buffer) {
     if (!buffer_cpy) {
         ret = 1;
 
+        ERR_SET(1, "Failed to copy buffer.");
+
         goto exit;
     }
 
@@ -88,7 +129,9 @@ int utils__http_request_parse(http_request_t* req, char* buffer) {
     char *headers_end = strstr(buffer_cpy, "\r\n\r\n");
 
     if (!headers_end) {
-        ret = 2;
+        ret = 1;
+
+        ERR_SET(2, "HTTP request malformed (missing '\\r\\n\\r\\n)' between headers and body if any).");
 
         goto exit;
     }
@@ -108,7 +151,7 @@ int utils__http_request_parse(http_request_t* req, char* buffer) {
         // The first line includes information on request (method, path, and HTTP version).
         if (line_num == 1) {
             if ((ret = utils__http_request_parse_info(req, line)) != 0) {
-                ret = 3;
+                ret = 1;
 
                 goto exit;
             }
@@ -116,7 +159,7 @@ int utils__http_request_parse(http_request_t* req, char* buffer) {
             // Check for header.
             if (utils__http_is_header(line)) {
                 if ((ret = utils__http_request_header_parse(req, line)) != 0) {
-                    ret = 4;
+                    ret = 1;
 
                     goto exit;
                 }
@@ -144,10 +187,11 @@ exit:
  * Generates the payload of a plain HTTP request.
  * 
  * @param req A pointer to the HTTP request.
+ * @param buffer The buffer to store the raw request text in.
  * 
- * @return A character pointer to the plain HTTP request or NULL on error.
+ * @return 0 on success or 1 on error.
  */
-char* utils__http_request_write(http_request_t* req) {
+int utils__http_request_write(http_request_t* req, char** buffer) {
     // We need to determine the full length request.
     size_t len = 0;
 
@@ -171,16 +215,19 @@ char* utils__http_request_write(http_request_t* req) {
     len++;
 
     // Allocate buffer to store request in.
-    char *buffer = malloc(len);
+    *buffer = malloc(len);
 
-    if (!buffer)
-        return NULL;
+    if (!*buffer) {
+        ERR_SET(1, "Failed to allocate buffer.");
+
+        return 1;
+    }
 
     // Create offset.
     size_t off = 0;
 
     // Write response information (method, path, and version).
-    off += snprintf(buffer + off, len - off, "%s %s %s\r\n", req->method, req->path, req->version);
+    off += snprintf(*buffer + off, len - off, "%s %s %s\r\n", req->method, req->path, req->version);
 
     // Add headers.
     for (int i = 0; i < req->headers_cnt; i++) {
@@ -189,19 +236,19 @@ char* utils__http_request_write(http_request_t* req) {
         if (!t->value)
             continue;
 
-        off += snprintf(buffer + off, len - off, "%s: %s\r\n", t->name, t->value);
+        off += snprintf(*buffer + off, len - off, "%s: %s\r\n", t->name, t->value);
     }
 
-    off += snprintf(buffer + off, len - off, "\r\n");
+    off += snprintf(*buffer + off, len - off, "\r\n");
 
     if (req->body) {
         size_t body_len = strlen(req->body);
 
-        memcpy(buffer + off, req->body, body_len);
+        memcpy(*buffer + off, req->body, body_len);
         off += body_len;
     }
 
-    buffer[off] = '\0';
+    (*buffer)[off] = '\0';
 
-    return buffer;
+    return 0;
 }

--- a/src/utils/http/request.h
+++ b/src/utils/http/request.h
@@ -24,4 +24,4 @@ struct http_request {
 int utils__http_request_parse_info(http_request_t* req, char* line);
 int utils__http_request_header_parse(http_request_t* req, char* line);
 int utils__http_request_parse(http_request_t* req, char* buffer);
-char* utils__http_request_write(http_request_t* req);
+int utils__http_request_write(http_request_t* req, char** buffer);

--- a/src/utils/http/response.h
+++ b/src/utils/http/response.h
@@ -6,6 +6,8 @@
 #include <utils/string/split.h>
 #include <utils/string/trim.h>
 
+#include <utils/error/error.h>
+
 #include <utils/http/common.h>
 
 #include <string.h>
@@ -22,4 +24,4 @@ struct http_response {
 } typedef http_response_t;
 
 int utils__http_response_header_parse(http_response_t* res, char* line);
-char* utils__http_response_write(http_response_t* res);
+int utils__http_response_write(http_response_t* res, char** buffer);


### PR DESCRIPTION
This PR implements a basic error management system under utils.

Source files should use the `ERR_SET(int code, const char* error_msg, ...args)` macro if you need to set a custom error. This simplifies the `utils__error_set()` function below by setting the function name automatically. The function name isn't used with the current error handling, but may be used in the future which is why I added the functionality.

From here, you can retrieve the error message and code like the following from the error context that is declared in the global scope.

```C
error_ctx_t *err = utils__error_ctx();

printf("Error: %s (%d)\n", err->msg, err->code);
```